### PR TITLE
Add Polish translations

### DIFF
--- a/res/values-pl/strings.xml
+++ b/res/values-pl/strings.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Pretty Good Music Player</string>
+    <string name="action_settings">Ustawienia</string>
+    <string name="title_activity_album_list">Albumy</string>
+    <string name="title_activity_song_list">Utwory</string>
+    <string name="title_activity_now_playing">Teraz Odtwarzane</string>
+    <string name="title_activity_settings">Ustawienia</string>
+    <string name="notification_title">Pretty Good Music Player</string>
+    <string name="notification_message">Odtwarzane</string>
+	<string name="ticker_text">Usługa Odtwarzania Muzyki</string>
+	<string name="next">Następny</string>
+	<string name="pause">Pauza</string>
+	<string name="play">Odtwórz</string>
+	<string name="previous">Poprzedni</string>
+    <string name="resume">Kontynuuj</string>
+    <string name="jumpback">Skocz w tył</string>
+    <string name="shuffle">Losowo</string>
+    
+    <!-- *********** -->
+    <!-- Preferences -->
+    <!-- *********** -->
+    
+    <!-- File Preferences -->
+    <string name="file_preferences_title">Ustawienia Plików</string>
+    <string name="choose_music_directory_prompt">Folder z Muzyką</string>
+    <string name="choose_music_directory_summary">Wybierz Folder Zawierający Artystów</string>
+	<string name="directorydialogprompt">Ścieżka do Folderu z Muzyką</string>
+    <string name="directorydialoghere">Tutaj!</string>
+    <string name="directorydialogup">Folder Wyżej</string>
+    
+    <!-- Theme Preferences -->
+    <string name="theme_title">Motyw</string>
+    <string name="light">Jasny</string>
+    <string name="dark">Ciemny</string>
+    <string name="small">Mały</string>
+    <string name="medium">Średni</string>
+    <string name="large">Duży</string>
+    <string name="style_preference_title">Ustawienia Stylów</string>
+    <string name="theme_select_prompt">Wybierz Motyw Odtwarzacza</string>
+    <string name="accent_color_title">Kolor</string>
+    <string name="custom_accent_color_title">Niestandardowy Kolor (aarrggbb)</string>
+    <string name="text_size_title">Rozmiar Tekstu</string>
+    <string name="text_size_prompt">Wybierz Rozmiar Tekstu Odtwarzacza</string>
+    <string name="full_screen_now_playing_title">Pełnoekranowe Teraz Odtwarzane</string>
+    <string name="ignore_leading_the_title">Pomiń \'The\' w Nazwie Artysty</string>
+    
+    <!-- Playback Preferences -->    
+    <string name="playback_title">Odtwarzanie</string>
+    <string name="headphone_disconnect_behavior">Zachowanie po Odłączeniu Słuchawek</string>
+    <string name="pause_immediately">Natychmiastowa Pauza</string>
+    <string name="pause_after_one_sec">Pauza po Jednej Sekundzie</string>
+    <string name="resume_on_quick_reconnect">Kontynuuj po Szybkim Ponownym Podłączeniu</string>
+    <string name="resume_on_reconnect">Kontynuuj po Ponownym Podłączeniu</string>
+    <string name="podcasts_and_audiobooks_title">Podkasty i Audiobooki</string>
+    <string name="audiobook_mode">Tryb Audiobook</string>
+</resources>

--- a/res/values-pl/theme-options.xml
+++ b/res/values-pl/theme-options.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array
+        name="themeoptions">
+        <item>Jasny</item>
+        <item>Ciemny</item>
+    </string-array>
+    <string-array
+        name="textsizeoptions">
+        <item>Mały</item>
+        <item>Średni</item>
+        <item>Duży</item>
+    </string-array>
+    <string-array
+        name="accentcoloroptions">
+        <item>Jasny Szary</item>
+        <item>Ciemny Szary</item>
+        <item>Niebieski</item>
+        <item>Pomarańczowy</item>
+        <item>Zielony</item>
+        <item>Żółty</item>
+        <item>Błękitny</item>
+        <item>Zielony 2</item>
+        <item>Niebieski 2</item>
+        <item>Niestandardowy</item>
+    </string-array>
+</resources>

--- a/res/xml/pretty_good_preferences.xml
+++ b/res/xml/pretty_good_preferences.xml
@@ -2,7 +2,9 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android" >
     <PreferenceCategory
         android:title="@string/file_preferences_title">
-        <Preference android:title="@string/choose_music_directory_prompt" 
+        <Preference 
+            android:key="choose_music_directory_prompt"
+            android:title="@string/choose_music_directory_prompt" 
             android:summary="@string/choose_music_directory_summary"
             android:icon="@android:drawable/ic_menu_set_as"/>
     </PreferenceCategory>

--- a/src/com/smithdtyler/prettygoodmusicplayer/SettingsActivity.java
+++ b/src/com/smithdtyler/prettygoodmusicplayer/SettingsActivity.java
@@ -103,7 +103,7 @@ public class SettingsActivity extends PreferenceActivity {
 			Preference preference) {
 		// TODO clean this up a bunch.
 		Log.i(TAG, "User clicked " + preference.getTitle());
-		if (preference.getTitle().equals("Choose Music Directory")) {
+		if (preference.getKey().equals("choose_music_directory_prompt")) {
 			final File path = Utils.getRootStorageDirectory();
 			DirectoryPickerOnClickListener picker = new DirectoryPickerOnClickListener(
 					this, path);


### PR DESCRIPTION
I noticed that "Choose Music Directory" was hardcoded and for this reason I was unable to open dialog window when this text was translated. 

I'm not 100% sure if this fix is done properly, but it works for me. If there is something wrong, you can just ignore it and cherry-pick my second commit.