### PR TITLE
Fix crash-on-close when wakelock is not held

### DIFF
--- a/src/com/smithdtyler/prettygoodmusicplayer/MusicPlaybackService.java
+++ b/src/com/smithdtyler/prettygoodmusicplayer/MusicPlaybackService.java
@@ -481,7 +481,9 @@ public class MusicPlaybackService extends Service {
 		mp.stop();
 		mp.reset();
 		mp.release();
-		wakeLock.release();
+		if (wakeLock.isHeld()) {
+			wakeLock.release();
+		}
 		Log.i("MyService", "Service Stopped.");
 		isRunning = false;
 	}


### PR DESCRIPTION
Before this patch when audio playback stopped pressing back until you
can exit the app caused an "app has crashed" dialog to appear. The
traceback was as follows:

 FATAL EXCEPTION: main
 Process: com.smithdtyler.prettygoodmusicplayer, PID: 22792
 java.lang.RuntimeException: Unable to stop service
     com.smithdtyler.prettygoodmusicplayer.MusicPlaybackService@2428d0f7:
     java.lang.RuntimeException: WakeLock under-locked

 Caused by: java.lang.RuntimeException: WakeLock under-locked PGMPWakeLock
        at android.os.PowerManager$WakeLock.release(PowerManager.java:1053)
        at android.os.PowerManager$WakeLock.release(PowerManager.java:1024)
        at com.smithdtyler.prettygoodmusicplayer.MusicPlaybackService.onDestroy(MusicPlaybackService.java:484)
        at android.app.ActivityThread.handleStopService(ActivityThread.java:2954)
        ... 9 more

The fix, as recommended by the wisdom of stackoverflow[0], is to add a
check to see if the wakelock is held before releasing it.

[0]: https://stackoverflow.com/a/14949367/4596